### PR TITLE
More aggressive configuration of supervisor. 

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,18 @@ nodaemon=true
 
 [program:ss-server]
 command=/usr/local/bin/ss-server -p %(ENV_SS_PORT)s -k %(ENV_SS_PASSWORD)s -m %(ENV_SS_METHOD)s -t %(ENV_SS_TIMEOUT)s -d 8.8.8.8 -d 208.67.222.222 -u --fast-open
+autostart=true
+startsecs=5
+stopwaitsecs=0
+autorestart=true
+startretries=3
+redirect_stderr=true
 
 [program:kcptun]
 command=/opt/kcptun/server_linux_amd64 -l :%(ENV_KCP_PORT)s -t 127.0.0.1:%(ENV_SS_PORT)s --crypt none --mtu %(ENV_MTU)s --sndwnd %(ENV_SNDWND)s --rcvwnd %(ENV_RCVWND)s --mode %(ENV_KCP_MODE)s --nocomp
-
+autostart=true
+startsecs=5
+stopwaitsecs=0
+autorestart=true
+startretries=3
+redirect_stderr=true


### PR DESCRIPTION
Recent build of `shadowsocks-libev` which contains defect might crash in some circumstance. Some docker service provider (e.g. Arukas) might killed the instance and re-allocate new one with new address and port, thus causing the service itself unstable. To prevent this from happening again, I've added those following to the configuration file. I've tested for 2 months and it's stable enough.